### PR TITLE
fix(doc): let users pick the latest version of lenses-ppx

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Then add it to bsconfig.json
 Then add lenses-ppx
 
 ```
-yarn add lenses-ppx@4.0.0 -D
+yarn add lenses-ppx -D
 ```
 
 And update your bsconfig.json with `ppx-flags`


### PR DESCRIPTION
< 5.0.0 was only intended for older versions